### PR TITLE
Add support for additional volumes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,24 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem"s dependencies in kitchen-libvirt.gemspec
 gemspec
 
 group :dev do
-  gem "rubocop"
-  gem "yard"
-  gem "maruku"
+  gem 'maruku'
+  gem 'pronto'
+  gem 'pronto-flay', require: false
+  gem 'pronto-rubocop', require: false
+  gem 'rubocop'
+  gem 'yard'
 end
 
 group :test do
-  gem "rake"
-  gem "pry"
+  gem 'pry'
+  gem 'rake'
 end
 
 group :changelog do
-  gem "github_changelog_generator"
+  gem 'github_changelog_generator'
 end

--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ For standard platforms we automatically provide the SSH username, but when speci
 
 A list of block device mappings for the machine.  An example of all available keys looks like:
 
-    devices:
-    - type: disk
-      format: qcow2
-      volume_size: 20
+    volumes:
+    - format: raw
+      pool: default
+      size: 20G
+      backing_volume: /var/lib/libvirt/golden.img
 
 ## Example
 
@@ -129,18 +130,31 @@ to override default configuration.
       name: libvirt
       uri: qemu:///session
     transport:
+      username: vagrant
       ssh_key: ~/.vagrant.d/insecure_private_key
 
     platforms:
       - name: ubuntu-16.04
       - name: centos-7
         driver:
-          vcpu: 2
+          cpus: 2
           memory: 2048
         transport:
           username: centos
 
     suites:
+      - name: default
+        driver:
+          volumes:
+            - format: qcow2
+              pool: default
+              size: 10G
+            - format: qcow2
+              pool: default
+              size: 10G
+        run_list:
+        attributes:
+
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,33 +1,33 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:test)
 
-require "rubocop/rake_task"
+require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:style) do |task|
-  task.options << "--display-cop-names"
+  task.options << '--display-cop-names'
 end
 
-desc "Run all quality tasks"
-task :quality => [:style]
+desc 'Run all quality tasks'
+task quality: [:style]
 
-require "yard"
+require 'yard'
 YARD::Rake::YardocTask.new
 
 begin
-  task :default => [:test, :quality]
+  task default: %i[test quality]
 
-  require "github_changelog_generator/task"
+  require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.future_release = Kitchen::Driver::LIBVIRT_VERSION
-    config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
-    config.bug_labels = "bug,Bug,Improvement".split(",")
-    config.exclude_labels = %w(invalid wontfix no_changelog)
+    config.enhancement_labels = 'enhancement,Enhancement,New Feature,Feature'.split(',')
+    config.bug_labels = 'bug,Bug,Improvement'.split(',')
+    config.exclude_labels = %w[invalid wontfix no_changelog]
   end
 rescue LoadError
   task :changelog do
-    raise "github_changelog_generator not installed! gem install github_changelog_generator."
+    raise 'github_changelog_generator not installed! gem install github_changelog_generator.'
   end
 end

--- a/examples/kitchen.yml
+++ b/examples/kitchen.yml
@@ -15,5 +15,11 @@ transport:
 
 suites:
   - name: default
+    driver:
+      extra_disks:
+        - format_type: raw
+          pool_name: 'default'
+          capacity: 10G 
     run_list:
     attributes:
+    

--- a/kitchen-libvirt.gemspec
+++ b/kitchen-libvirt.gemspec
@@ -1,5 +1,6 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/libvirt_version.rb'
 
@@ -20,8 +21,8 @@ Gem::Specification.new do |gem|
 
   # gem.required_ruby_version = '>= 2.2.2'
 
+  gem.add_dependency 'fog-libvirt', '~> 0.5.0'
   gem.add_dependency 'test-kitchen', '~> 1.4', '>= 1.4.1'
-  gem.add_dependency 'fog-libvirt', '~> 0.5.0' 
 
   gem.add_development_dependency 'rspec',     '~> 3.2'
   gem.add_development_dependency 'simplecov', '~> 0.7'

--- a/lib/kitchen/driver/libvirt_version.rb
+++ b/lib/kitchen/driver/libvirt_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Libvirt Test Kitchen driver
-    LIBVIRT_VERSION = "0.1.0"
+    LIBVIRT_VERSION = "0.2.0"
   end
 end

--- a/lib/kitchen/driver/libvirt_version.rb
+++ b/lib/kitchen/driver/libvirt_version.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 #
 # Author:: Brandon Raabe (<brandocorp@gmail.com>)
 #
@@ -17,10 +17,8 @@
 # limitations under the License.
 
 module Kitchen
-
   module Driver
-
     # Version string for Libvirt Test Kitchen driver
-    LIBVIRT_VERSION = "0.2.0"
+    LIBVIRT_VERSION = '0.2.0'
   end
 end

--- a/spec/kitchen/driver/libvirt_spec.rb
+++ b/spec/kitchen/driver/libvirt_spec.rb
@@ -37,37 +37,39 @@ describe Kitchen::Driver::Libvirt do
   let(:image) do
     double("source_image",
       path: '/var/lib/images/image.img',
-      pool_name: 'default', 
+      pool_name: 'default',
       format_type: 'raw'
     )
   end
 
-  let(:volume) do 
-    { 
+  let(:volume) do
+    double(
+      'libvirt volume',
       path: '/var/lib/images/volume.img',
-      pool_name: 'default', 
-      format_type: 'raw' 
-    }
+      pool_name: 'default',
+      format_type: 'raw',
+      destroy: true
+    )
   end
 
   let(:nic) do
-    { 
-      type: 'network', 
-      network: 'default' 
+    {
+      type: 'network',
+      network: 'default'
     }
   end
-  
+
   let(:domain_options) do
     {
-      name: "default-testos-99-0123456789", 
-      persistent: true, 
+      name: "default-testos-99-0123456789",
+      persistent: true,
       cpus: 1,
-      memory_size: 512, 
-      os_type: 'hvm', 
-      arch: 'x86_64', 
+      memory_size: 512,
+      os_type: 'hvm',
+      arch: 'x86_64',
       domain_type: 'kvm',
       nics: [nic],
-      volumes: [volume] 
+      volumes: [volume]
     }
   end
 
@@ -81,18 +83,20 @@ describe Kitchen::Driver::Libvirt do
     double("Fog::Compute")
   end
 
-  let(:domain) do 
+  let(:domain) do
     double(
-      "libvirt domain", 
-      id: id, 
+      'libvirt domain',
+      id: id,
       name: "default-testos-99-0123456789",
       public_ip_address: '1.2.3.4',
       start: true,
       volumes: [volume],
       nics: [nic],
+      halt: true,
+      active: true
     )
   end
-  
+
   let(:instance) do
     instance_double(
       Kitchen::Instance,
@@ -110,7 +114,7 @@ describe Kitchen::Driver::Libvirt do
     allow(driver).to receive(:instance).and_return(instance)
     allow(driver).to receive(:client).and_return(client)
     allow(client).to receive_message_chain("servers.create").and_return(domain)
-    allow(driver).to receive(:create_volume).and_return(volume)
+    allow(driver).to receive(:domain_volumes).and_return([volume])
   end
 
   it "driver api_version is 2" do

--- a/spec/kitchen/driver/libvirt_spec.rb
+++ b/spec/kitchen/driver/libvirt_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 #
 # Author:: Brandon Raabe (<brandocorp@gmail.com>)
 #
@@ -16,35 +16,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "fog/libvirt"
-require "kitchen/driver/libvirt"
-require "kitchen/provisioner/dummy"
-require "kitchen/transport/dummy"
-require "kitchen/verifier/dummy"
+require 'fog/libvirt'
+require 'kitchen/driver/libvirt'
+require 'kitchen/provisioner/dummy'
+require 'kitchen/transport/dummy'
+require 'kitchen/verifier/dummy'
 
 describe Kitchen::Driver::Libvirt do
-
   let(:logged_output) { StringIO.new }
-  let(:logger)        { Logger.new(logged_output) }
+  let(:logger) { Logger.new(logged_output) }
   let(:config) do
     {
       uri: 'qemu:///system',
       cpus: 2,
-      memory: 2048,
+      memory: 2048
     }
   end
 
   let(:image) do
-    double("source_image",
-      path: '/var/lib/images/image.img',
-      pool_name: 'default',
-      format_type: 'raw'
-    )
+    double('source_image',
+           path: '/var/lib/images/image.img',
+           pool_name: 'default',
+           format_type: 'raw')
   end
 
   let(:volume) do
     double(
       'libvirt volume',
+      key: '/var/lib/images/volume.img',
       path: '/var/lib/images/volume.img',
       pool_name: 'default',
       format_type: 'raw',
@@ -61,7 +60,7 @@ describe Kitchen::Driver::Libvirt do
 
   let(:domain_options) do
     {
-      name: "default-testos-99-0123456789",
+      name: 'default-testos-99-0123456789',
       persistent: true,
       cpus: 1,
       memory_size: 512,
@@ -73,21 +72,21 @@ describe Kitchen::Driver::Libvirt do
     }
   end
 
-  let(:platform) { Kitchen::Platform.new(:name => "testos-99") }
+  let(:platform) { Kitchen::Platform.new(name: 'testos-99') }
   let(:transport) { Kitchen::Transport::Dummy.new }
   let(:provisioner) { Kitchen::Provisioner::Dummy.new }
   let(:state) { {} }
   let(:driver) { Kitchen::Driver::Libvirt.new(config) }
-  let(:id) { "12345678-abcd-efgh-ijkl-mnopqrstuvwx" }
+  let(:id) { '12345678-abcd-efgh-ijkl-mnopqrstuvwx' }
   let(:client) do
-    double("Fog::Compute")
+    double('Fog::Compute')
   end
 
   let(:domain) do
     double(
       'libvirt domain',
       id: id,
-      name: "default-testos-99-0123456789",
+      name: 'default-testos-99-0123456789',
       public_ip_address: '1.2.3.4',
       start: true,
       volumes: [volume],
@@ -100,12 +99,12 @@ describe Kitchen::Driver::Libvirt do
   let(:instance) do
     instance_double(
       Kitchen::Instance,
-      :name => "default-testos-99",
-      :logger => logger,
-      :transport => transport,
-      :provisioner => provisioner,
-      :platform => platform,
-      :to_str => "str"
+      name: 'default-testos-99',
+      logger: logger,
+      transport: transport,
+      provisioner: provisioner,
+      platform: platform,
+      to_str: 'str'
     )
   end
 
@@ -113,52 +112,52 @@ describe Kitchen::Driver::Libvirt do
     allow(driver).to receive(:windows_os?).and_return(false)
     allow(driver).to receive(:instance).and_return(instance)
     allow(driver).to receive(:client).and_return(client)
-    allow(client).to receive_message_chain("servers.create").and_return(domain)
+    allow(client).to receive_message_chain('servers.create').and_return(domain)
     allow(driver).to receive(:domain_volumes).and_return([volume])
   end
 
-  it "driver api_version is 2" do
+  it 'driver api_version is 2' do
     expect(driver.diagnose_plugin[:api_version]).to eq(2)
   end
 
-  it "plugin_version is set to Kitchen::Vagrant::VERSION" do
+  it 'plugin_version is set to Kitchen::Vagrant::VERSION' do
     expect(driver.diagnose_plugin[:version]).to eq(Kitchen::Driver::LIBVIRT_VERSION)
   end
 
-  describe "#create" do
-    it "returns if an existing instance id is found" do
+  describe '#create' do
+    it 'returns if an existing instance id is found' do
       state[:server_id] = id
       expect(driver.create(state)).to eq(nil)
     end
 
-    it "sets the domain ip address as the hostname" do
+    it 'sets the domain ip address as the hostname' do
       driver.create(state)
-      expect(state[:server_id]).to eq("12345678-abcd-efgh-ijkl-mnopqrstuvwx")
+      expect(state[:server_id]).to eq('12345678-abcd-efgh-ijkl-mnopqrstuvwx')
       expect(state[:hostname]).to eq('1.2.3.4')
     end
   end
 
-  describe "#destroy" do
-    context "when no server id is found" do
-      it "returns nil" do
+  describe '#destroy' do
+    context 'when no server id is found' do
+      it 'returns nil' do
         expect(driver.destroy(state)).to eq(nil)
       end
     end
 
-    context "when an existing instance id is found" do
-      let(:state) { { :server_id => "id", :hostname => "name" } }
+    context 'when an existing instance id is found' do
+      let(:state) { { server_id: 'id', hostname: 'name' } }
 
-      context "the server is already destroyed" do
-        it "does nothing" do
-          expect(driver).to receive(:load_domain).with("id").and_return nil
+      context 'the server is already destroyed' do
+        it 'does nothing' do
+          expect(driver).to receive(:load_domain).with('id').and_return nil
           driver.destroy(state)
           expect(state).to eq({})
         end
       end
 
-      it "destroys the server" do
-        expect(driver).to receive(:load_domain).with("id").and_return(domain)
-        expect(instance).to receive_message_chain("transport.connection.close")
+      it 'destroys the server' do
+        expect(driver).to receive(:load_domain).with('id').and_return(domain)
+        expect(instance).to receive_message_chain('transport.connection.close')
         expect(domain).to receive(:destroy)
         driver.destroy(state)
         expect(state).to eq({})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 #
 # Author:: Brandon Raabe (<brandocorp@gmail.com>)
 #
@@ -16,20 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ENV["CODECLIMATE_REPO_TOKEN"]
-  require "codeclimate-test-reporter"
+if ENV['CODECLIMATE_REPO_TOKEN']
+  require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
-elsif ENV["COVERAGE"]
-  require "simplecov"
-  SimpleCov.profiles.define "gem" do
-    command_name "Specs"
+elsif ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.profiles.define 'gem' do
+    command_name 'Specs'
 
-    add_filter ".gem/"
-    add_filter "/spec/"
+    add_filter '.gem/'
+    add_filter '/spec/'
 
-    add_group "Libraries", "/lib/"
+    add_group 'Libraries', '/lib/'
   end
-  SimpleCov.start "gem"
+  SimpleCov.start 'gem'
 end
 
 RSpec.configure do |config|
@@ -46,17 +47,14 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = true
 
-  if config.files_to_run.one?
-    config.default_formatter = "doc"
-  end
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.order = :random
 
   Kernel.srand config.seed
 
   config.expose_dsl_globally = true
-
 end
 
-require "fog/libvirt"
-require "support/fog"
+require 'fog/libvirt'
+require 'support/fog'

--- a/spec/support/fog.rb
+++ b/spec/support/fog.rb
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 #
 # Author:: Brandon Raabe (<brandocorp@gmail.com>)
 #


### PR DESCRIPTION
This PR adds support for configuring `extra_volumes` as an array of hashes. Each hash represents the configuration for a new `Libvirt::Volume`.

## Example:
```yaml
---
driver:
  name: libvirt
  volumes:
    - format_type: raw
      capacity: 20G
      pool_name: default
    - format_type: raw
      capacity: 100G
      pool_name: xxl_pool
```