### PR TITLE
Fix create method to update state with ip address before attempting SSH.

### DIFF
--- a/lib/kitchen/driver/libvirt.rb
+++ b/lib/kitchen/driver/libvirt.rb
@@ -76,15 +76,17 @@ module Kitchen
         return if state[:server_id]
 
         domain = create_domain
-        instance.transport.connection(state).wait_until_ready
         state[:server_id] = domain.id
         state[:hostname] = domain.public_ip_address
+
+        instance.transport.connection(state).wait_until_ready
+
         info("Libvirt instance #{domain.name} created.")
       end
 
       # Destroy the target instance
       def destroy(state)
-        info("Creating instance #{instance.name}")
+        info("Destroying instance #{instance.name}")
         return if state[:server_id].nil?
         instance.transport.connection(state).close
         domain = load_domain(state[:server_id])


### PR DESCRIPTION
When creating a domain, the state needs to be updated with the domain's IP address. Currently the method is attempting to wait for SSH to come up before it knows the IP address of the domain.