### PR TITLE
Raise an error if source volume is not found.

### DIFF
--- a/lib/kitchen/driver/libvirt.rb
+++ b/lib/kitchen/driver/libvirt.rb
@@ -163,7 +163,14 @@ module Kitchen
       def clone_volume(source, target)
         debug("Creating Libvirt volume #{target}")
         debug("Cloning volume from #{source}")
+
+        # Attempt to locate the target or source volume
         source_image = client.volumes.get(source)
+        if source_image.name =~ /^fog-\d+/
+          error("Could not find target image: #{source}.")
+        end
+
+        # Clone the source volume
         source_image.clone_volume(target)
         client.volumes.all.find { |vol| vol.name == target }
       end

--- a/lib/kitchen/driver/libvirt_version.rb
+++ b/lib/kitchen/driver/libvirt_version.rb
@@ -19,6 +19,6 @@
 module Kitchen
   module Driver
     # Version string for Libvirt Test Kitchen driver
-    LIBVIRT_VERSION = '0.2.1'
+    LIBVIRT_VERSION = '0.2.2'
   end
 end


### PR DESCRIPTION
When a source volume can't be found, display an error message letting the user know.